### PR TITLE
[refresh-qcloud-cdn] adapt for usm and yggdrasil-api]

### DIFF
--- a/refresh-qcloud-cdn/package.json
+++ b/refresh-qcloud-cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "refresh-qcloud-cdn",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "title": "刷新腾讯云 CDN",
   "description": "当角色信息被更新时，自动刷新 CDN 中的 JSON Profile。",
   "author": "GPlane",

--- a/refresh-qcloud-cdn/package.json
+++ b/refresh-qcloud-cdn/package.json
@@ -6,7 +6,7 @@
   "author": "GPlane",
   "namespace": "GPlane\\RefreshQcloudCdn",
   "require": {
-    "blessing-skin-server": "^4.0.0 || ^5"
+    "blessing-skin-server": "^5"
   },
   "enchants": {
     "icon": {


### PR DESCRIPTION
适配 BS v5 中与核心分离的 UniSkinAPI 和 Yggdrasil API 的角色属性部分。