### PR TITLE
 [yggdrasil-api] Remove openssl_free_key()

### DIFF
--- a/plugins/yggdrasil-api/src/Models/Profile.php
+++ b/plugins/yggdrasil-api/src/Models/Profile.php
@@ -118,7 +118,7 @@ class Profile
             }
 
             unset($prop);
-            openssl_free_key($key);
+            unset($key);
         }
 
         return json_encode($result, JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
[openssl_free_key](https://www.php.net/manual/en/function.openssl-free-key.php)
> Warning
This function has been DEPRECATED as of PHP 8.0.0. Relying on this function is highly discouraged.