### PR TITLE
[yggdrasil-api] implement Mojang publickeys API

### DIFF
--- a/plugins/yggdrasil-api/routes.php
+++ b/plugins/yggdrasil-api/routes.php
@@ -18,6 +18,11 @@ Route::prefix('authserver')
         Route::post('invalidate', 'AuthController@invalidate');
     });
 
+Route::prefix('minecraftservices')
+    ->group(function () {
+        Route::get('publickeys', 'ServicesController@getPublicKeys');
+    });
+
 Route::prefix('sessionserver/session/minecraft')->group(function () {
     Route::post('join', 'SessionController@joinServer');
     Route::get('hasJoined', 'SessionController@hasJoinedServer');

--- a/plugins/yggdrasil-api/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-api/src/Controllers/ConfigController.php
@@ -10,7 +10,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Option;
-use Yggdrasil\Exceptions\IllegalArgumentException;
+use Yggdrasil\Utils\Key;
 
 class ConfigController extends Controller
 {
@@ -77,17 +77,7 @@ class ConfigController extends Controller
             $request->getHost(),
         ]))));
 
-        $privateKey = openssl_pkey_get_private(option('ygg_private_key'));
-
-        if (!$privateKey) {
-            throw new IllegalArgumentException(trans('Yggdrasil::config.rsa.invalid'));
-        }
-
-        $keyData = openssl_pkey_get_details($privateKey);
-
-        if ($keyData['bits'] < 4096) {
-            throw new IllegalArgumentException(trans('Yggdrasil::config.rsa.length'));
-        }
+        $privateKey = Key::getPrivateKey(config('ygg_private_key'));
 
         $result = [
             'meta' => [
@@ -100,7 +90,7 @@ class ConfigController extends Controller
                 'feature.non_email_login' => true,
             ],
             'skinDomains' => $skinDomains,
-            'signaturePublickey' => $keyData['key'],
+            'signaturePublickey' => Key::getPublicKey($privateKey),
         ];
 
         if (!optional($pluginManager->get('disable-registration'))->isEnabled()) {

--- a/plugins/yggdrasil-api/src/Controllers/ServicesController.php
+++ b/plugins/yggdrasil-api/src/Controllers/ServicesController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Yggdrasil\Controllers;
+
+use Illuminate\Routing\Controller;
+use Yggdrasil\Utils\Key;
+
+class ServicesController extends Controller
+{
+    public function getPublicKeys()
+    {
+        $privateKey = Key::getPrivateKey(config('ygg_private_key'));
+
+        $result = [
+            'profilePropertyKeys' => [
+                [
+                    'publicKey' => Key::getPublicKey($privateKey)
+                ]
+            ],
+            'playerCertificateKeys' => [
+                [
+                    'pulicKey' => Key::getPublicKey($privateKey)
+                ]
+            ]
+        ];
+
+        return json($result);
+    }
+}

--- a/plugins/yggdrasil-api/src/Models/Profile.php
+++ b/plugins/yggdrasil-api/src/Models/Profile.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Http;
 use Log;
 use Ramsey\Uuid\Uuid;
 use Schema;
-use Yggdrasil\Exceptions\IllegalArgumentException;
+use Yggdrasil\Utils\Key;
 
 class Profile
 {
@@ -46,11 +46,7 @@ class Profile
 
         // 检查 RSA 私钥
         if ($unsigned === false) {
-            $key = openssl_pkey_get_private(option('ygg_private_key'));
-
-            if (!$key) {
-                throw new IllegalArgumentException(trans('Yggdrasil::config.rsa.invalid'));
-            }
+            $key = Key::getPrivateKey(config('ygg_private_key'));
 
             $textures['signatureRequired'] = true;
         }

--- a/plugins/yggdrasil-api/src/Utils/Key.php
+++ b/plugins/yggdrasil-api/src/Utils/Key.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Yggdrasil\Utils;
+
+use Yggdrasil\Exceptions\IllegalArgumentException;
+
+class Key
+{
+    public static function getPrivateKey($key)
+    {
+        $privateKey = openssl_pkey_get_private(option('ygg_private_key'));
+
+        if (!$privateKey) {
+            throw new IllegalArgumentException(trans('Yggdrasil::config.rsa.invalid'));
+        }
+
+        return $privateKey;
+    }
+
+    public static function getPublicKey($key)
+    {
+        $keyData = openssl_pkey_get_details($key);
+
+        if ($keyData['bits'] < 4096) {
+            throw new IllegalArgumentException(trans('Yggdrasil::config.rsa.length'));
+        }
+
+        return $keyData['key'];
+    }
+}


### PR DESCRIPTION
实现 Mojang 的 Publickeys API, 新版本的 authlib 已经将公钥从jar内置移至此 API