### PR TITLE
[yggdrasil-api] log rotation for verbose log

### DIFF
--- a/plugins/yggdrasil-api/bootstrap.php
+++ b/plugins/yggdrasil-api/bootstrap.php
@@ -11,10 +11,18 @@ require __DIR__.'/src/Utils/helpers.php';
 
 return function (Filter $filter, Dispatcher $events) {
     if (env('YGG_VERBOSE_LOG')) {
-        config(['logging.channels.ygg' => [
-            'driver' => 'single',
-            'path' => storage_path('logs/yggdrasil.log'),
-        ]]);
+        if (env('YGG_VERBOSE_LOG_DAYS')) {
+            config(['logging.channels.ygg' => [
+                'driver' => 'daily',
+                'days' => env('YGG_VERBOSE_LOG_DAYS'),
+                'path' => storage_path('logs/yggdrasil.log'),
+            ]]);
+        } else {
+            config(['logging.channels.ygg' => [
+                'driver' => 'single',
+                'path' => storage_path('logs/yggdrasil.log'),
+            ]]);
+        }
     } else {
         config(['logging.channels.ygg' => [
             'driver' => 'monolog',

--- a/plugins/yggdrasil-api/bootstrap.php
+++ b/plugins/yggdrasil-api/bootstrap.php
@@ -11,18 +11,11 @@ require __DIR__.'/src/Utils/helpers.php';
 
 return function (Filter $filter, Dispatcher $events) {
     if (env('YGG_VERBOSE_LOG')) {
-        if (env('YGG_VERBOSE_LOG_DAYS')) {
-            config(['logging.channels.ygg' => [
-                'driver' => 'daily',
-                'days' => env('YGG_VERBOSE_LOG_DAYS'),
-                'path' => storage_path('logs/yggdrasil.log'),
-            ]]);
-        } else {
-            config(['logging.channels.ygg' => [
-                'driver' => 'single',
-                'path' => storage_path('logs/yggdrasil.log'),
-            ]]);
-        }
+        config(['logging.channels.ygg' => [
+            'driver' => 'daily',
+            'days' => env('YGG_VERBOSE_LOG_DAYS'),
+            'path' => storage_path('logs/yggdrasil.log'),
+        ]]);
     } else {
         config(['logging.channels.ygg' => [
             'driver' => 'monolog',


### PR DESCRIPTION
一周 5G 的日志是真顶不住（

---

如果 .env 中定义了 `YGG_VERBOSE_LOG_DAYS`，则会将 Yggdrasil API 的 verbose log 的 driver 设置为 daily，days 为 `YGG_VERBOSE_LOG_DAYS` 的值，让 Laravel 自动处理 verbose log 的 log rotation