### PR TITLE
修复 legacy-api 插件 404 问题

### DIFF
--- a/plugins/legacy-api/README.md
+++ b/plugins/legacy-api/README.md
@@ -1,0 +1,6 @@
+# 使用方法
+启动插件后，使用 `皮肤站地址/skin/{PlayerName}` 来访问玩家皮肤材质， `皮肤站地址/cape/{PlayerName}` 来访问玩家披风材质。
+
+# 示例
+- `example.com/skin/Steve`
+- `example.com/cape/Steve`

--- a/plugins/legacy-api/bootstrap.php
+++ b/plugins/legacy-api/bootstrap.php
@@ -6,8 +6,8 @@ return function () {
     Hook::addRoute(function () {
         Route::namespace('Blessing\Legacy')
             ->group(function () {
-                Route::get('/skin/{player}.png', 'TextureController@skin');
-                Route::get('/cape/{player}.png', 'TextureController@cape');
+                Route::get('/skin/{player}', 'TextureController@skin');
+                Route::get('/cape/{player}', 'TextureController@cape');
             });
     });
 };

--- a/plugins/legacy-api/package.json
+++ b/plugins/legacy-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legacy-api",
   "title": "Blessing\\Legacy::general.title",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Blessing\\Legacy::general.description",
   "author": "GPlane",
   "url": "https://gplane.win/",


### PR DESCRIPTION
- 修复了使用插件提供的 API 获取材质时 404 的问题
- 为插件添加了使用说明