### PR TITLE
添加自定义gravatar镜像的环境变量

### DIFF
--- a/plugins/gravatar/bootstrap.php
+++ b/plugins/gravatar/bootstrap.php
@@ -9,7 +9,8 @@ return function (Filter $filter) {
         }
 
         $hashed = md5(strtolower(trim($user->email)));
-
-        return "https://www.gravatar.com/avatar/$hashed";
+        $registry = env('GRAVATAR_REGISTRY');
+        
+        return "$registry$hashed";
     });
 };

--- a/plugins/gravatar/bootstrap.php
+++ b/plugins/gravatar/bootstrap.php
@@ -9,7 +9,7 @@ return function (Filter $filter) {
         }
 
         $hashed = md5(strtolower(trim($user->email)));
-        $registry = env('GRAVATAR_REGISTRY', 'https://gravatar.loli.net/avatar/');
+        $registry = env('GRAVATAR_REGISTRY', 'https://www.gravatar.com/avatar/');
         
         return "$registry$hashed";
     });

--- a/plugins/gravatar/bootstrap.php
+++ b/plugins/gravatar/bootstrap.php
@@ -9,7 +9,7 @@ return function (Filter $filter) {
         }
 
         $hashed = md5(strtolower(trim($user->email)));
-        $registry = env('GRAVATAR_REGISTRY');
+        $registry = env('GRAVATAR_REGISTRY', 'https://gravatar.loli.net/avatar/');
         
         return "$registry$hashed";
     });


### PR DESCRIPTION
鉴于gravatar在国内访问受阻的问题，添加了`GRAVATAR_REGISTRY`这一环境变量，可自定义gravatar源

环境变量示例：
`GRAVATAR_REGISTRY=https://gravatar.loli.net/avatar/`