### PR TITLE
添加 Mojang 的公钥 API

### DIFF
--- a/plugins/yggdrasil-api/routes.php
+++ b/plugins/yggdrasil-api/routes.php
@@ -34,3 +34,5 @@ Route::prefix('api/user/profile')
         Route::put('{uuid}/{type}', 'ProfileController@uploadTexture');
         Route::delete('{uuid}/{type}', 'ProfileController@resetTexture');
     });
+
+Route::get('minecraftservices/publickeys', 'ConfigController@getPublicKeys');

--- a/plugins/yggdrasil-api/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-api/src/Controllers/ConfigController.php
@@ -133,7 +133,6 @@ class ConfigController extends Controller
         $result = [
             'profilePropertyKeys' => [['publicKey' => $publicKeyBase64]],
             'playerCertificateKeys' => [['publicKey' => $publicKeyBase64]],
-            'authenticationKeys' => array(['publicKey' => $publicKeyBase64]),
         ];
 
         return json($result);

--- a/plugins/yggdrasil-api/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-api/src/Controllers/ConfigController.php
@@ -131,8 +131,8 @@ class ConfigController extends Controller
         );
 
         $result = [
-            'profilePropertyKeys' => array(['publicKey' => $publicKeyBase64]),
-            'playerCertificateKeys' => array(['publicKey' => $publicKeyBase64]),
+            'profilePropertyKeys' => [['publicKey' => $publicKeyBase64]],
+            'playerCertificateKeys' => [['publicKey' => $publicKeyBase64]],
             'authenticationKeys' => array(['publicKey' => $publicKeyBase64]),
         ];
 

--- a/plugins/yggdrasil-api/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-api/src/Controllers/ConfigController.php
@@ -122,7 +122,7 @@ class ConfigController extends Controller
 
     public function getPublicKeys()
     {
-        $keyData = $this->getPkey();
+        $keyData = $this->getPrivateKey();
 
         $publicKeyBase64 = str_replace(
             array("-----BEGIN PUBLIC KEY-----", "-----END PUBLIC KEY-----", "\n"),

--- a/plugins/yggdrasil-api/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-api/src/Controllers/ConfigController.php
@@ -77,7 +77,7 @@ class ConfigController extends Controller
             $request->getHost(),
         ]))));
 
-        $signaturePublickey = $this->getPkey();
+        $signaturePublickey = $this->getPrivateKey();
 
         $result = [
             'meta' => [

--- a/plugins/yggdrasil-api/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-api/src/Controllers/ConfigController.php
@@ -139,7 +139,7 @@ class ConfigController extends Controller
         return json($result);
     }
 
-    public function getPkey(): string
+    public function getPrivateKey(): string
     {
         $privateKey = openssl_pkey_get_private(option('ygg_private_key'));
 

--- a/plugins/yggdrasil-connect/routes.php
+++ b/plugins/yggdrasil-connect/routes.php
@@ -41,3 +41,5 @@ Route::prefix('api/user/profile')
         Route::put('{uuid}/{type}', 'ProfileController@uploadTexture');
         Route::delete('{uuid}/{type}', 'ProfileController@resetTexture');
     });
+
+Route::get('minecraftservices/publickeys', 'ConfigController@getPublicKeys');

--- a/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
@@ -156,7 +156,7 @@ class ConfigController extends Controller
 
     public function getPublicKeys(): JsonResponse
     {
-        $keyData = $this->getPkey();
+        $keyData = $this->getPrivateKey();
 
         $publicKeyBase64 = str_replace(
             array("-----BEGIN PUBLIC KEY-----", "-----END PUBLIC KEY-----", "\n"),

--- a/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
@@ -173,7 +173,7 @@ class ConfigController extends Controller
         return json($result);
     }
 
-    public function getPkey(): string
+    public function getPrivateKey(): string
     {
         $privateKey = openssl_pkey_get_private(option('ygg_private_key'));
 

--- a/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
@@ -165,8 +165,8 @@ class ConfigController extends Controller
         );
 
         $result = [
-            'profilePropertyKeys' => array(['publicKey' => $publicKeyBase64]),
-            'playerCertificateKeys' => array(['publicKey' => $publicKeyBase64]),
+            'profilePropertyKeys' => [['publicKey' => $publicKeyBase64]],
+            'playerCertificateKeys' => [['publicKey' => $publicKeyBase64]],
             'authenticationKeys' => array(['publicKey' => $publicKeyBase64]),
         ];
 

--- a/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
@@ -103,7 +103,7 @@ class ConfigController extends Controller
             $request->getHost(),
         ]))));
 
-        $signaturePublickey = $this->getPkey();
+        $signaturePublickey = $this->getPrivateKey();
 
         $result = [
             'meta' => [

--- a/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
+++ b/plugins/yggdrasil-connect/src/Controllers/ConfigController.php
@@ -167,7 +167,6 @@ class ConfigController extends Controller
         $result = [
             'profilePropertyKeys' => [['publicKey' => $publicKeyBase64]],
             'playerCertificateKeys' => [['publicKey' => $publicKeyBase64]],
-            'authenticationKeys' => array(['publicKey' => $publicKeyBase64]),
         ];
 
         return json($result);


### PR DESCRIPTION
参考了此 API 实现 https://api.minecraftservices.com/publickeys

将 BlessingSkin 设置为 Drasl 的 FallbackAPIServers 时，Drasl 在启动时会请求 ``/api/yggdrasil/minecraftservices/publickeys`` ，产生一个 HTTP 404 错误

```log
drasl  | 2026/01/10 12:49:06 Request to fallback API server at http://blessingskin/api/yggdrasil/minecraftservices/publickeys resulted in status code 404
```

尽管不影响使用，但消除了 Drasl 的报错